### PR TITLE
stream prefix upd

### DIFF
--- a/modules/backend/task-definition/cli.json.tpl
+++ b/modules/backend/task-definition/cli.json.tpl
@@ -79,7 +79,7 @@
       "options": {
         "awslogs-group": "${log_group}",
         "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "cli"
+        "awslogs-stream-prefix": "dspace"
       }
     }
   }

--- a/modules/backend/task-definition/rest.json.tpl
+++ b/modules/backend/task-definition/rest.json.tpl
@@ -162,7 +162,7 @@
       "options": {
         "awslogs-group": "${log_group}",
         "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "backend"
+        "awslogs-stream-prefix": "dspace"
       }
     }
   }

--- a/modules/frontend/task-definition/frontend.json.tpl
+++ b/modules/frontend/task-definition/frontend.json.tpl
@@ -56,7 +56,7 @@
       "options": {
         "awslogs-group": "${log_group}",
         "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "frontend"
+        "awslogs-stream-prefix": "dspace"
       }
     }
   }

--- a/modules/solr/task-definition/solr.json.tpl
+++ b/modules/solr/task-definition/solr.json.tpl
@@ -43,7 +43,7 @@
       "options": {
         "awslogs-group": "${log_group}",
         "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "solr"
+        "awslogs-stream-prefix": "dspace"
       }
     }
   }


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
