### PR TITLE
services example test

### DIFF
--- a/examples/services/README.md
+++ b/examples/services/README.md
@@ -2,6 +2,9 @@
 
 Configuration in this directory creates DSpace services.
 
+*Note: this example is used for internal testing and is not
+intended for general use other than as a reference.*
+
 ## Usage
 
 To run this example you need to create `terraform.tfvars`:
@@ -23,8 +26,6 @@ efs_name                 = "dspace-efs"
 domain                   = "dspace.org"
 frontend_img             = "dspace/dspace-angular:dspace-7_x-dist"
 lb_name                  = "dspace-lb"
-profile                  = "default"
-profile_for_dns          = "default"
 security_group_name      = "dspace-private-app"
 solr_discovery_namespace = "dspace.solr"
 solr_img                 = "dspace/dspace-solr:dspace-7_x"
@@ -45,9 +46,6 @@ The key ones are:
   - the name of an existing EFS
 - `lb_name`
   - the name of an existing ALB
-- `profile_for_dns`
-  - set to a different profile if necessary
-  - this profile should contain the hosted zone for `domain`
 - `security_group_name`
   - the name of an existing security group
 - `solr_discovery_namespace`
@@ -64,6 +62,3 @@ terraform init
 terraform plan
 terraform apply
 ```
-
-Note that this example creates resources which cost money. Run terraform destroy
-when you don't need these resources.

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -1,12 +1,30 @@
-provider "aws" {
-  region  = local.region
-  profile = var.profile
+terraform {
+  cloud {
+    organization = "Lyrasis"
+
+    workspaces {
+      tags = ["dspace", "test"]
+    }
+  }
 }
 
 provider "aws" {
-  region  = local.region
-  profile = var.profile_for_dns
-  alias   = "dns"
+  region              = local.region
+  allowed_account_ids = [var.project_account_id]
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.project_account_id}:role/${var.role}"
+  }
+}
+
+provider "aws" {
+  alias               = "dns"
+  region              = local.region
+  allowed_account_ids = [var.dns_account_id]
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.dns_account_id}:role/${var.role}"
+  }
 }
 
 locals {

--- a/examples/services/variables.tf
+++ b/examples/services/variables.tf
@@ -10,14 +10,6 @@ variable "frontend_img" {
   default = "dspace/dspace-angular:dspace-7_x-dist"
 }
 
-variable "profile" {
-  default = "default"
-}
-
-variable "profile_for_dns" {
-  default = "default"
-}
-
 variable "solr_img" {
   default = "dspace/dspace-solr:dspace-7_x"
 }
@@ -32,6 +24,14 @@ data "aws_route53_zone" "selected" {
 ################################################################################
 # External resources
 ################################################################################
+variable "department" {}
+variable "dns_account_id" {}
+variable "environment" {}
+variable "project_account_id" {}
+variable "region" {}
+variable "role" {}
+variable "service" {}
+### module
 variable "cluster_name" {}
 variable "db_host" {}
 variable "db_name" {}


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
