### PR TITLE
ec2 awsvpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ resource "aws_service_discovery_private_dns_namespace" "this" {
 }
 ```
 
-*Note: currently this module only supports Fargate deployments. Also supporting EC2 may be added in the future.*
-
 Module configuration:
 
 ```hcl
@@ -175,6 +173,20 @@ network_mode             = "bridge"
 requires_compatibilities = ["EC2"]
 target_type              = "instance"
 ```
+
+*Note: this configuration is not currently supported for the Solr module.*
+
+To deploy to an ECS/EC2 auto-scaling group with `awsvpc` network mode:
+
+```ini
+capacity_provider        = "EC2"
+network_mode             = "awsvpc"
+requires_compatibilities = ["EC2"]
+target_type              = "ip" # omit for Solr module
+```
+
+*Note: this configuration is supported for the Solr module but has
+[specific requirements](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html).*
 
 To deploy to Fargate (the default):
 

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -53,6 +53,11 @@ module "solr" {
   service_discovery_id = data.aws_service_discovery_dns_namespace.solr.id
   subnets              = data.aws_subnets.selected.ids
   vpc_id               = data.aws_vpc.selected.id
+
+  # networking (tests Solr on ec2 with service discovery)
+  capacity_provider        = "EC2"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
 }
 
 module "backend" {
@@ -69,7 +74,8 @@ module "backend" {
   host              = "${local.name}.${var.domain}"
   img               = var.backend_img
   listener_arn      = data.aws_lb_listener.selected.arn
-  listener_priority = 1
+  listener_priority = 4999
+  log4j2_url        = "https://raw.githubusercontent.com/dts-hosting/terraform-aws-dspace/main/files/log4j2-container.xml" # TODO: rm when PR merged
   name              = "${local.name}-backend"
   namespace         = "/server"
   security_group_id = data.aws_security_group.selected.id
@@ -92,7 +98,7 @@ module "frontend" {
   host              = "${local.name}.${var.domain}"
   img               = var.frontend_img
   listener_arn      = data.aws_lb_listener.selected.arn
-  listener_priority = 2
+  listener_priority = 4999
   name              = "${local.name}-frontend"
   namespace         = "/"
   rest_host         = "${local.name}.${var.domain}"

--- a/modules/backend/lb.tf
+++ b/modules/backend/lb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "this" {
-  name                 = var.name
+  name_prefix          = var.name
   port                 = var.port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
@@ -18,6 +18,10 @@ resource "aws_lb_target_group" "this" {
   stickiness {
     enabled = true
     type    = "lb_cookie"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/modules/frontend/lb.tf
+++ b/modules/frontend/lb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "this" {
-  name                 = var.name
+  name_prefix          = var.name
   port                 = var.port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id
@@ -18,6 +18,10 @@ resource "aws_lb_target_group" "this" {
   stickiness {
     enabled = true
     type    = "lb_cookie"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
