### PR TITLE
tg name prefixes

### DIFF
--- a/modules/backend/lb.tf
+++ b/modules/backend/lb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "this" {
-  name_prefix          = var.name
+  name_prefix          = "api"
   port                 = var.port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id

--- a/modules/frontend/lb.tf
+++ b/modules/frontend/lb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "this" {
-  name_prefix          = var.name
+  name_prefix          = "ui"
   port                 = var.port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
