### PR TITLE
upd cpu alloc

### DIFF
--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -46,6 +46,7 @@ module "solr" {
   source = "../../modules/solr"
 
   cluster_id           = data.aws_ecs_cluster.selected.id
+  cpu                  = null
   efs_id               = data.aws_efs_file_system.selected.id
   img                  = var.solr_img
   name                 = "${local.name}-solr"

--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -32,8 +32,8 @@ resource "aws_ecs_task_definition" "this" {
   family                   = "${var.name}-${each.key}"
   network_mode             = each.key == "cli" ? "awsvpc" : var.network_mode
   requires_compatibilities = each.key == "cli" ? ["FARGATE"] : var.requires_compatibilities
-  cpu                      = (var.capacity_provider == "FARGATE" || each.key == "cli") ? var.cpu : null
-  memory                   = var.memory
+  cpu                      = each.key == "cli" ? var.cli_cpu : var.cpu
+  memory                   = each.key == "cli" ? var.cli_memory : var.memory
   execution_role_arn       = aws_iam_role.this.arn
   task_role_arn            = aws_iam_role.this.arn
 

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -12,12 +12,22 @@ variable "capacity_provider" {
   default = "FARGATE"
 }
 
+variable "cli_cpu" {
+  description = "Task level cpu allocation for cli"
+  default     = 1024
+}
+
+variable "cli_memory" {
+  description = "Task level memory allocation for cli"
+  default     = 2048
+}
+
 variable "cluster_id" {
   description = "ECS cluster id"
 }
 
 variable "cpu" {
-  description = "Task level cpu allocation (Fargate only)"
+  description = "Task level cpu allocation"
   default     = 1024
 }
 

--- a/modules/frontend/ecs.tf
+++ b/modules/frontend/ecs.tf
@@ -2,7 +2,7 @@ resource "aws_ecs_task_definition" "this" {
   family                   = var.name
   network_mode             = var.network_mode
   requires_compatibilities = var.requires_compatibilities
-  cpu                      = var.capacity_provider == "FARGATE" ? var.cpu : null
+  cpu                      = var.cpu
   memory                   = var.memory
   execution_role_arn       = aws_iam_role.this.arn
   task_role_arn            = aws_iam_role.this.arn

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -13,7 +13,7 @@ variable "cluster_id" {
 }
 
 variable "cpu" {
-  description = "Task level cpu allocation (Fargate only)"
+  description = "Task level cpu allocation"
   default     = 512
 }
 

--- a/modules/solr/ecs.tf
+++ b/modules/solr/ecs.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_task_definition" "this" {
   family                   = var.name
   network_mode             = var.network_mode
   requires_compatibilities = var.requires_compatibilities
-  cpu                      = var.capacity_provider == "FARGATE" ? var.cpu : null
+  cpu                      = var.cpu
   memory                   = var.memory
   execution_role_arn       = aws_iam_role.this.arn
   task_role_arn            = aws_iam_role.this.arn

--- a/modules/solr/variables.tf
+++ b/modules/solr/variables.tf
@@ -13,7 +13,7 @@ variable "cluster_id" {
 }
 
 variable "cpu" {
-  description = "Task level cpu allocation (Fargate only)"
+  description = "Task level cpu allocation"
   default     = 512
 }
 


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Don't restrict cpu alloc to fargate
