### PR TITLE
update srv doc

### DIFF
--- a/examples/services/README.md
+++ b/examples/services/README.md
@@ -7,33 +7,24 @@ intended for general use other than as a reference.*
 
 ## Usage
 
-To run this example you need to create `terraform.tfvars`:
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+Without a `terraform.tfvars` file the deployment will use the
+default configuration (c.f. hosting repository).
+
+### Override configuration
+
+Optionally create `terraform.tfvars`:
 
 ```bash
 cp terraform.tfvars.example terraform.tfvars
 ```
 
 Update the values as appropriate:
-
-```bash
-backend_img              = "dspace/dspace:dspace-7_x"
-cluster_name             = "dspace-cluster"
-db_host                  = "database.dspace.org"
-db_name                  = "dspace"
-db_password_param        = "dspace-db-password"
-db_username_param        = "dspace-db-username"
-efs_name                 = "dspace-efs"
-domain                   = "dspace.org"
-frontend_img             = "dspace/dspace-angular:dspace-7_x-dist"
-lb_name                  = "dspace-lb"
-security_group_name      = "dspace-private-app"
-solr_discovery_namespace = "dspace.solr"
-solr_img                 = "dspace/dspace-solr:dspace-7_x"
-subnet_type              = "Private"
-vpc_name                 = "dspace-vpc"
-```
-
-The key ones are:
 
 - `cluster_name`
   - the name of an existing ECS cluster
@@ -54,11 +45,3 @@ The key ones are:
   - the type (by tag) of existing subnets
 - `vpc_name`
   - the name of an existing vpc
-
-Then execute:
-
-```bash
-terraform init
-terraform plan
-terraform apply
-```


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
