### PR TITLE
services url

### DIFF
--- a/examples/services/README.md
+++ b/examples/services/README.md
@@ -16,6 +16,10 @@ terraform apply
 Without a `terraform.tfvars` file the deployment will use the
 default configuration (c.f. hosting repository).
 
+This will create:
+
+- https://dspace-ex-services.dspace.org
+
 ### Override configuration
 
 Optionally create `terraform.tfvars`:


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
