### PR TITLE
frontend custom vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ Given this example, the frontend would be available at:
 
 For all configuration options review the [variables file](modules/frontend/variables.tf).
 
+#### Custom environment and secrets configuration
+
+Custom (non-predefined) environment and secrets configuration can be defined:
+
+```hcl
+custom_env_cfg = {
+  "DSPACE_CACHE_SERVERSIDE_ANONYMOUSCACHE_MAX" = "500",
+  "NEW_RELIC_APP_NAME" = "dspace-frontend"
+}
+custom_secrets_cfg = {
+  "NEW_RELIC_LICENSE_KEY" = "arn:aws:ssm:us-east-2:111222333444:parameter/newrelic_license_key"
+}
+```
+
 ## Launch type configuration
 
 The `backend` (api) and `frontend` modules can deploy to either

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -107,6 +107,10 @@ module "frontend" {
   security_group_id = data.aws_security_group.selected.id
   subnets           = data.aws_subnets.selected.ids
   vpc_id            = data.aws_vpc.selected.id
+
+  custom_env_cfg = {
+    "DSPACE_CACHE_SERVERSIDE_ANONYMOUSCACHE_MAX" = "500"
+  }
 }
 
 ################################################################################

--- a/modules/frontend/ecs.tf
+++ b/modules/frontend/ecs.tf
@@ -8,21 +8,23 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn            = aws_iam_role.this.arn
 
   container_definitions = templatefile("${path.module}/task-definition/frontend.json.tpl", {
-    env            = var.env
-    bind           = "0.0.0.0"
-    img            = var.img
-    log_group      = aws_cloudwatch_log_group.this.name
-    memory         = var.memory
-    name           = var.name
-    namespace      = var.namespace
-    network_mode   = var.network_mode
-    port           = var.port
-    region         = data.aws_region.current.name
-    rest_host      = var.rest_host
-    rest_namespace = var.rest_namespace
-    rest_port      = var.rest_port
-    rest_ssl       = var.rest_ssl
-    ssl            = "false" # ssl termination handled by alb
+    custom_env_cfg     = var.custom_env_cfg
+    custom_secrets_cfg = var.custom_secrets_cfg
+    env                = var.env
+    bind               = "0.0.0.0"
+    img                = var.img
+    log_group          = aws_cloudwatch_log_group.this.name
+    memory             = var.memory
+    name               = var.name
+    namespace          = var.namespace
+    network_mode       = var.network_mode
+    port               = var.port
+    region             = data.aws_region.current.name
+    rest_host          = var.rest_host
+    rest_namespace     = var.rest_namespace
+    rest_port          = var.rest_port
+    rest_ssl           = var.rest_ssl
+    ssl                = "false" # ssl termination handled by alb
   })
 }
 

--- a/modules/frontend/task-definition/frontend.json.tpl
+++ b/modules/frontend/task-definition/frontend.json.tpl
@@ -5,6 +5,12 @@
     "networkMode": "${network_mode}",
     "essential": true,
     "environment": [
+      %{ for name, value in custom_env_cfg }
+      {
+        "name": "${name}",
+        "value": "${value}"
+      },
+      %{ endfor ~}
       {
         "name": "DSPACE_UI_SSL",
         "value": "${ssl}"
@@ -45,6 +51,14 @@
         "name": "NODE_OPTIONS",
         "value": "--max-old-space-size=${memory}"
       }
+    ],
+    "secrets": [
+      %{ for name, value in custom_secrets_cfg }
+      {
+        "name": "${name}",
+        "valueFrom": "${value}"
+      },
+      %{ endfor ~}
     ],
     "portMappings": [
       {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -17,6 +17,16 @@ variable "cpu" {
   default     = 512
 }
 
+variable "custom_env_cfg" {
+  default     = {}
+  description = "General environment name/value configuration"
+}
+
+variable "custom_secrets_cfg" {
+  default     = {}
+  description = "General secrets name/value configuration"
+}
+
 variable "env" {
   description = "DSpace frontend env (node)"
   default     = "production"


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
