### PR TITLE
var for dspace name

### DIFF
--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -10,6 +10,7 @@ locals {
     db_password_arn    = var.db_password_arn
     db_url             = "jdbc:postgresql://${var.db_host}:5432/${var.db_name}"
     db_username_arn    = var.db_username_arn
+    dspace_name        = var.dspace_name
     dspace_dir         = "/dspace" # TODO: var?
     frontend_url       = var.frontend_url
     host               = var.host

--- a/modules/backend/task-definition/cli.json.tpl
+++ b/modules/backend/task-definition/cli.json.tpl
@@ -25,7 +25,7 @@
       },
       {
         "name": "dspace__P__name",
-        "value": "${name}"
+        "value": "${dspace_name}"
       },
       {
         "name": "dspace__P__server__P__url",

--- a/modules/backend/task-definition/rest.json.tpl
+++ b/modules/backend/task-definition/rest.json.tpl
@@ -97,7 +97,7 @@
       },
       {
         "name": "dspace__P__name",
-        "value": "${name}"
+        "value": "${dspace_name}"
       },
       {
         "name": "dspace__P__server__P__url",

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -32,13 +32,13 @@ variable "cpu" {
 }
 
 variable "custom_env_cfg" {
-  default     = {}
   description = "General environment name/value configuration"
+  default     = {}
 }
 
 variable "custom_secrets_cfg" {
-  default     = {}
   description = "General secrets name/value configuration"
+  default     = {}
 }
 
 variable "db_host" {
@@ -55,6 +55,11 @@ variable "db_password_arn" {
 
 variable "db_username_arn" {
   description = "DSpace db username SSM parameter arn"
+}
+
+variable "dspace_name" {
+  description = "Short and sweet site name"
+  default     = "DSpace at My University"
 }
 
 variable "efs_id" {


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
