### PR TITLE
redirects

### DIFF
--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -73,6 +73,11 @@ variable "port" {
   default     = 4000
 }
 
+variable "redirects" {
+  description = "Redirect frontend paths to rest server"
+  default     = ["oai", "sword"]
+}
+
 variable "requires_compatibilities" {
   default = ["FARGATE"]
 }


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
