### PR TITLE
robots txt

### DIFF
--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -111,6 +111,8 @@ module "frontend" {
   custom_env_cfg = {
     "DSPACE_CACHE_SERVERSIDE_ANONYMOUSCACHE_MAX" = "500"
   }
+
+  robots_txt = file("${path.module}/robots.txt")
 }
 
 ################################################################################

--- a/examples/services/robots.txt
+++ b/examples/services/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/modules/frontend/lb.tf
+++ b/modules/frontend/lb.tf
@@ -56,12 +56,46 @@ resource "aws_lb_listener_rule" "redirect" {
       values = ["${var.namespace}${each.value}*"]
     }
   }
+
+  depends_on = [aws_lb_listener_rule.this, aws_lb_listener_rule.robots]
+}
+
+resource "aws_lb_listener_rule" "robots" {
+  count = try(var.robots_txt, null) != null ? 1 : 0
+
+  listener_arn = var.listener_arn
+  # force differentiate value passed to backend module
+  priority = var.listener_priority * 10 + (length(var.redirects) + 1)
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = var.robots_txt
+      status_code  = "200"
+    }
+  }
+
+  condition {
+    host_header {
+      values = [var.host]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["${var.namespace}robots.txt"]
+    }
+  }
+
+  depends_on = [aws_lb_listener_rule.this]
 }
 
 resource "aws_lb_listener_rule" "this" {
   listener_arn = var.listener_arn
   # force differentiate value passed to backend module
-  priority = var.listener_priority * 10 + (length(var.redirects) + 1)
+  priority = var.listener_priority * 10 + (length(var.redirects) + 2)
 
   action {
     type             = "forward"

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -101,6 +101,12 @@ variable "rest_ssl" {
   default     = true
 }
 
+variable "robots_txt" {
+  description = "DSpace frontend custom robots.txt"
+  default     = null
+  type        = string
+}
+
 variable "security_group_id" {
   description = "Security group id"
 }


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
