### PR TITLE
certbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Configuration for the DSpace frontend (Angular UI):
 module "frontend" {
   source = "../../modules/frontend"
 
-  cluster_id        = var_efs_id
+  cluster_id        = var.cluster_id
   host              = "example.dspace.org"
   img               = var.frontend_img
   listener_arn      = var.listener_arn
@@ -159,6 +159,35 @@ Given this example, the frontend would be available at:
 - `https://example.dspace.org`
 
 For all configuration options review the [variables file](modules/frontend/variables.tf).
+
+### Certbot
+
+Optional module for `http` -> `https` redirection when a certbot certificate is required. If you
+cannot use ACM directly and / or would otherwise prefer to generate an SSL certificate using
+certbot this module runs an nginx proxy as a service that will support certbot webroot
+challenges. To do this the `listener_arn` must be for an `http` listener: http requests will be
+allowed through to the certbot container and redirected to https unless responding to certbot
+challenges. If certificate generation is successful the certificate is uploaded to ACM and
+registered with the specified load balancer (identified by name).
+
+```hcl
+module "certbot" {
+  source = "../../modules/certbot"
+
+  cluster_id        = var.cluster_id
+  email             = "example@dspace.org"
+  enabled           = true
+  hostname          = "example.dspace.org"
+  lb_name           = var.lb_name
+  listener_arn      = var.listener_arn
+  name              = "demo-certbot"
+  security_group_id = data.aws_security_group.selected.id
+  subnets           = data.aws_subnets.selected.ids
+  vpc_id            = data.aws_vpc.selected.id
+}
+```
+
+For more details on the certbot container refer to [docker-certbot-acm](https://github.com/dts-hosting/docker-certbot-acm).
 
 #### Custom environment and secrets configuration
 

--- a/examples/services/main.tf
+++ b/examples/services/main.tf
@@ -115,6 +115,22 @@ module "frontend" {
   robots_txt = file("${path.module}/robots.txt")
 }
 
+module "certbot" {
+  source = "../../modules/certbot"
+
+  capacity_provider = "FARGATE_SPOT"
+  cluster_id        = data.aws_ecs_cluster.selected.id
+  email             = "no-reply@${var.domain}"
+  enabled           = true
+  hostname          = "${local.name}.${var.domain}"
+  lb_name           = var.lb_name
+  listener_arn      = data.aws_lb_listener.http.arn
+  name              = "${local.name}-certbot"
+  security_group_id = data.aws_security_group.selected.id
+  subnets           = data.aws_subnets.selected.ids
+  vpc_id            = data.aws_vpc.selected.id
+}
+
 ################################################################################
 # Supporting resources
 ################################################################################

--- a/examples/services/variables.tf
+++ b/examples/services/variables.tf
@@ -58,6 +58,11 @@ data "aws_lb" "selected" {
   name = var.lb_name
 }
 
+data "aws_lb_listener" "http" {
+  load_balancer_arn = data.aws_lb.selected.arn
+  port              = 80
+}
+
 data "aws_lb_listener" "selected" {
   load_balancer_arn = data.aws_lb.selected.arn
   port              = 443

--- a/modules/certbot/README.md
+++ b/modules/certbot/README.md
@@ -1,0 +1,1 @@
+# DSpace certbot module

--- a/modules/certbot/ecs.tf
+++ b/modules/certbot/ecs.tf
@@ -1,0 +1,62 @@
+locals {
+  task_config = {
+    email        = var.email
+    enabled      = var.enabled ? "true" : "false"
+    hostname     = var.hostname
+    img          = var.img
+    lb_name      = var.lb_name
+    port         = var.port
+    log_group    = aws_cloudwatch_log_group.this.name
+    network_mode = var.network_mode
+    region       = data.aws_region.current.name
+  }
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  network_mode             = var.network_mode
+  requires_compatibilities = var.requires_compatibilities
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.this.arn
+  task_role_arn            = aws_iam_role.this.arn
+
+  container_definitions = templatefile("${path.module}/task-definition/certbot.json.tpl", local.task_config)
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.instances
+
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+
+  enable_execute_command = true
+
+  capacity_provider_strategy {
+    capacity_provider = var.capacity_provider
+    weight            = 100
+  }
+
+  load_balancer {
+    container_name   = "certbot"
+    container_port   = var.port
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+
+  dynamic "network_configuration" {
+    for_each = var.network_mode == "awsvpc" ? ["true"] : []
+    content {
+      assign_public_ip = var.assign_public_ip
+      security_groups  = [var.security_group_id]
+      subnets          = var.subnets
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/ecs/${var.name}"
+  retention_in_days = 7
+}

--- a/modules/certbot/iam.tf
+++ b/modules/certbot/iam.tf
@@ -1,0 +1,50 @@
+resource "aws_iam_role" "this" {
+  name = var.name
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com",
+          "ecs.amazonaws.com",
+          "ecs-tasks.amazonaws.com",
+          "events.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AWSCertificateManagerFullAccess",
+    "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
+  ]
+
+  inline_policy {
+    name = "ECSTaskPassRole"
+
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action   = ["iam:PassRole"]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}

--- a/modules/certbot/lb.tf
+++ b/modules/certbot/lb.tf
@@ -1,0 +1,47 @@
+resource "aws_lb_target_group" "this" {
+  name_prefix          = "certs-"
+  port                 = var.port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = var.target_type
+  deregistration_delay = 0
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    timeout             = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    matcher             = "200-299,301"
+  }
+
+  stickiness {
+    enabled = true
+    type    = "lb_cookie"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener_rule" "this" {
+  listener_arn = var.listener_arn
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+
+  condition {
+    host_header {
+      values = [var.hostname]
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["*"]
+    }
+  }
+}

--- a/modules/certbot/task-definition/certbot.json.tpl
+++ b/modules/certbot/task-definition/certbot.json.tpl
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "certbot",
+    "image": "${img}",
+    "networkMode": "${network_mode}",
+    "essential": true,
+    "environment": [
+      {
+        "name": "CERTBOT_ALB_NAME",
+        "value": "${lb_name}"
+      },
+      {
+        "name": "CERTBOT_DOMAINS",
+        "value": "${hostname}"
+      },
+      {
+        "name": "CERTBOT_EMAIL",
+        "value": "${email}"
+      },
+      {
+        "name": "CERTBOT_ENABLED",
+        "value": "${enabled}"
+      }
+    ],
+    "portMappings": [
+      {
+        "containerPort": ${port}
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "dspace"
+      }
+    }
+  }
+]

--- a/modules/certbot/variables.tf
+++ b/modules/certbot/variables.tf
@@ -1,0 +1,84 @@
+data "aws_region" "current" {}
+
+variable "assign_public_ip" {
+  default = false
+}
+
+variable "capacity_provider" {
+  default = "FARGATE"
+}
+
+variable "cluster_id" {
+  description = "ECS cluster id"
+}
+
+variable "cpu" {
+  description = "Task level cpu allocation"
+  default     = 256
+}
+
+variable "email" {
+  description = "Email address for certbot registration"
+}
+
+variable "enabled" {
+  description = "Enable certbot cert generation (otherwise http -> https redirection only)"
+}
+
+variable "hostname" {
+  description = "Hostname to generate certificate for"
+}
+
+variable "img" {
+  description = "Certbot docker img"
+  default     = "lyrasis/certbot-acm:latest"
+}
+
+variable "instances" {
+  default = 1
+}
+
+variable "lb_name" {
+  description = "Load balancer (name) to associate with certificate"
+}
+
+variable "listener_arn" {
+  description = "ALB (http) listener arn"
+}
+
+variable "memory" {
+  default = 512
+}
+
+variable "name" {
+  description = "AWS ECS resources name/alias (service name, task definition name etc.)"
+}
+
+variable "network_mode" {
+  default = "awsvpc"
+}
+
+variable "port" {
+  description = "Certbot port"
+  default     = 80
+}
+
+variable "requires_compatibilities" {
+  default = ["FARGATE"]
+}
+
+variable "security_group_id" {
+  description = "Security group id"
+}
+
+variable "subnets" {
+  description = "Subnets"
+}
+
+variable "target_type" {
+  default = "ip"
+}
+
+variable "vpc_id" {
+  description = "VPC id"
+}

--- a/modules/certbot/versions.tf
+++ b/modules/certbot/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
- Implement (optional) certbot module
