### PR TITLE
memory

### DIFF
--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -17,7 +17,7 @@ locals {
     img                = var.img
     log_group          = aws_cloudwatch_log_group.this.name
     log4j2_url         = var.log4j2_url
-    memory             = var.memory
+    memory             = var.dspace_xmx
     name               = var.name
     network_mode       = var.network_mode
     port               = var.port

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -18,8 +18,8 @@ variable "cli_cpu" {
 }
 
 variable "cli_memory" {
-  description = "Task level memory allocation for cli"
-  default     = 2048
+  description = "Task level memory allocation for cli (hard limit)"
+  default     = 3072
 }
 
 variable "cluster_id" {
@@ -62,6 +62,11 @@ variable "dspace_name" {
   default     = "DSpace at My University"
 }
 
+variable "dspace_xmx" {
+  description = "Container level memory allocation for DSpace (rest and cli)"
+  default     = 2048
+}
+
 variable "efs_id" {
   description = "EFS id"
 }
@@ -96,7 +101,8 @@ variable "log4j2_url" {
 }
 
 variable "memory" {
-  default = 2048
+  description = "Task level memory allocation (hard limit)"
+  default     = 3072
 }
 
 variable "name" {

--- a/modules/frontend/ecs.tf
+++ b/modules/frontend/ecs.tf
@@ -14,7 +14,7 @@ resource "aws_ecs_task_definition" "this" {
     bind               = "0.0.0.0"
     img                = var.img
     log_group          = aws_cloudwatch_log_group.this.name
-    memory             = var.memory
+    memory             = var.max_old_space_size
     name               = var.name
     namespace          = var.namespace
     network_mode       = var.network_mode

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -52,8 +52,14 @@ variable "listener_priority" {
   description = "ALB (https) listener priority (actual value is: int * 10 + 1)"
 }
 
+variable "max_old_space_size" {
+  description = "Container level memory allocation (frontend / node)"
+  default     = 768
+}
+
 variable "memory" {
-  default = 1024
+  description = "Task level memory allocation (hard limit)"
+  default     = 1024
 }
 
 variable "name" {

--- a/modules/solr/ecs.tf
+++ b/modules/solr/ecs.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_task_definition" "this" {
     data           = local.data_volume
     img            = var.img
     log_group      = aws_cloudwatch_log_group.this.name
-    memory         = var.memory
+    memory         = var.solr_java_mem
     network_mode   = var.network_mode
     name           = var.name
     port           = var.port

--- a/modules/solr/variables.tf
+++ b/modules/solr/variables.tf
@@ -30,7 +30,8 @@ variable "instances" {
 }
 
 variable "memory" {
-  default = 1024
+  dedescription = "Task level memory allocation (hard limit)"
+  default       = 1024
 }
 
 variable "name" {
@@ -60,6 +61,11 @@ variable "service_discovery_id" {
 
 variable "service_discovery_dns_type" {
   default = "A"
+}
+
+variable "solr_java_mem" {
+  description = "Container level memory allocation (solr)"
+  default     = 768
 }
 
 variable "subnets" {


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
- Implement (optional) certbot module
- Add vars for separate task and container memory allocation
