### PR TITLE
frontend autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,23 @@ Given this example, the frontend would be available at:
 
 For all configuration options review the [variables file](modules/frontend/variables.tf).
 
+#### Autoscaling
+
+For the frontend there is an autoscaling policy which can be configured by:
+
+```hcl
+autoscaling_cpu_threshold = 75
+autoscaling_max_capacity  = 3 # max no. of instances
+```
+
+The minimum capacity is set to 1.
+
+The policy overrides `[var.]instances` so to fully stop the frontend service you need to
+target the autoscaling group policy not the ECS service (when using the AWS cli for example).
+
+This feature requires sticky sessions which is enabled on the target group created by
+this module.
+
 ### Certbot
 
 Optional module for `http` -> `https` redirection when a certbot certificate is required. If you

--- a/modules/frontend/autoscaling.tf
+++ b/modules/frontend/autoscaling.tf
@@ -1,0 +1,24 @@
+resource "aws_appautoscaling_target" "this" {
+  max_capacity       = var.autoscaling_max_capacity
+  min_capacity       = 1
+  resource_id        = "service/${var.cluster_id}/${var.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "cpu" {
+  name               = var.name
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.this.resource_id
+  service_namespace  = aws_appautoscaling_target.this.service_namespace
+  scalable_dimension = aws_appautoscaling_target.this.scalable_dimension
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value = var.autoscaling_cpu_threshold
+  }
+}
+
+# TODO: other policies may be added in the future

--- a/modules/frontend/ecs.tf
+++ b/modules/frontend/ecs.tf
@@ -59,6 +59,10 @@ resource "aws_ecs_service" "this" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   tags = var.tags
 }
 

--- a/modules/frontend/iam.tf
+++ b/modules/frontend/iam.tf
@@ -10,6 +10,7 @@ resource "aws_iam_role" "this" {
       "Effect": "Allow",
       "Principal": {
         "Service": [
+          "application-autoscaling.amazonaws.com",
           "ec2.amazonaws.com",
           "ecs.amazonaws.com",
           "ecs-tasks.amazonaws.com"
@@ -26,6 +27,7 @@ EOF
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
-    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/aws-service-role/AWSApplicationAutoscalingECSServicePolicy"
   ]
 }

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -4,6 +4,16 @@ variable "assign_public_ip" {
   default = false
 }
 
+variable "autoscaling_cpu_threshold" {
+  description = "The % cpu utilization that when exceeded triggers a scale out event"
+  default     = 75
+}
+
+variable "autoscaling_max_capacity" {
+  description = "The maximum number of instances that can be run"
+  default     = 1
+}
+
 variable "capacity_provider" {
   default = "FARGATE"
 }
@@ -41,7 +51,8 @@ variable "img" {
 }
 
 variable "instances" {
-  default = 1
+  description = "The default number of instances to launch"
+  default     = 1
 }
 
 variable "listener_arn" {


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
- Implement (optional) certbot module
- Add vars for separate task and container memory allocation
- Fix description typo
- Support ecs app autoscaling for the frontend
