### PR TITLE
sns

### DIFF
--- a/modules/frontend/iam.tf
+++ b/modules/frontend/iam.tf
@@ -26,8 +26,8 @@ EOF
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
-    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+    "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-    "arn:aws:iam::aws:policy/aws-service-role/AWSApplicationAutoscalingECSServicePolicy"
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
   ]
 }


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
- Implement (optional) certbot module
- Add vars for separate task and container memory allocation
- Fix description typo
- Support ecs app autoscaling for the frontend
- Allow sns for task role
