### PR TITLE
frontend cw access

### DIFF
--- a/modules/frontend/autoscaling.tf
+++ b/modules/frontend/autoscaling.tf
@@ -1,7 +1,7 @@
 resource "aws_appautoscaling_target" "this" {
   max_capacity       = var.autoscaling_max_capacity
   min_capacity       = 1
-  resource_id        = "service/${var.cluster_id}/${var.name}"
+  resource_id        = "service/${split("/", var.cluster_id)[1]}/${var.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
 }

--- a/modules/frontend/iam.tf
+++ b/modules/frontend/iam.tf
@@ -12,8 +12,10 @@ resource "aws_iam_role" "this" {
         "Service": [
           "application-autoscaling.amazonaws.com",
           "ec2.amazonaws.com",
+          "ecs.application-autoscaling.amazonaws.com",
           "ecs.amazonaws.com",
-          "ecs-tasks.amazonaws.com"
+          "ecs-tasks.amazonaws.com",
+          "events.amazonaws.com"
         ]
       },
       "Action": "sts:AssumeRole",
@@ -28,6 +30,8 @@ EOF
     "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
     "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess",
+    "arn:aws:iam::aws:policy/CloudWatchFullAccess",
     "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
   ]
 }


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
- Implement (optional) certbot module
- Add vars for separate task and container memory allocation
- Fix description typo
- Support ecs app autoscaling for the frontend
- Allow sns for task role (#43)
- Give cw and ssm read access & fix app autoscale cluster name
