### PR TITLE
startup script

### DIFF
--- a/modules/backend/ecs.tf
+++ b/modules/backend/ecs.tf
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "ordered_placement_strategy" {
-    for_each = local.placement_strategies
+    for_each = !strcontains(local.capacity_provider, "FARGATE") ? local.placement_strategies : {}
     content {
       field = ordered_placement_strategy.value.field
       type  = ordered_placement_strategy.value.type

--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -32,6 +32,7 @@ locals {
   requires_compatibilities = var.requires_compatibilities
   security_group_id        = var.security_group_id
   solr_url                 = var.solr_url
+  startup_script           = var.startup_script
   subnets                  = var.subnets
   swap_size                = 2048
   tags                     = var.tags
@@ -65,6 +66,7 @@ locals {
     port               = local.port
     region             = data.aws_region.current.name
     solr_url           = local.solr_url
+    startup_script     = local.startup_script
     swap_size          = local.swap_size
     timezone           = local.timezone
   }

--- a/modules/backend/task-definition/rest.json.tpl
+++ b/modules/backend/task-definition/rest.json.tpl
@@ -76,6 +76,7 @@
       "-c",
       "${join(" ", [
         "${dspace_dir}/bin/dspace database migrate;",
+        "${startup_script};",
         "catalina.sh run"
       ])}"
     ],

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -143,6 +143,11 @@ variable "solr_url" {
   description = "DSpace solr url"
 }
 
+variable "startup_script" {
+  description = "A script or command to run before starting the DSpace server"
+  default     = "date"
+}
+
 variable "subnets" {
   description = "Subnets"
 }

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -118,6 +118,7 @@ variable "network_mode" {
 }
 
 variable "placement_strategies" {
+  description = "Placement strategies (does not apply when capacity provider is FARGATE)"
   default = {
     pack-by-memory = {
       field = "memory"

--- a/modules/certbot/ecs.tf
+++ b/modules/certbot/ecs.tf
@@ -42,7 +42,7 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "ordered_placement_strategy" {
-    for_each = local.placement_strategies
+    for_each = !strcontains(local.capacity_provider, "FARGATE") ? local.placement_strategies : {}
     content {
       field = ordered_placement_strategy.value.field
       type  = ordered_placement_strategy.value.type

--- a/modules/certbot/variables.tf
+++ b/modules/certbot/variables.tf
@@ -59,6 +59,7 @@ variable "network_mode" {
 }
 
 variable "placement_strategies" {
+  description = "Placement strategies (does not apply when capacity provider is FARGATE)"
   default = {
     pack-by-memory = {
       field = "memory"

--- a/modules/frontend/ecs.tf
+++ b/modules/frontend/ecs.tf
@@ -42,7 +42,7 @@ resource "aws_ecs_service" "this" {
   }
 
   dynamic "ordered_placement_strategy" {
-    for_each = local.placement_strategies
+    for_each = !strcontains(local.capacity_provider, "FARGATE") ? local.placement_strategies : {}
     content {
       field = ordered_placement_strategy.value.field
       type  = ordered_placement_strategy.value.type

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -86,6 +86,7 @@ variable "network_mode" {
 }
 
 variable "placement_strategies" {
+  description = "Placement strategies (does not apply when capacity provider is FARGATE)"
   default = {
     pack-by-memory = {
       field = "memory"

--- a/modules/solr/ecs.tf
+++ b/modules/solr/ecs.tf
@@ -49,7 +49,7 @@ resource "aws_ecs_service" "solr" {
   }
 
   dynamic "ordered_placement_strategy" {
-    for_each = local.placement_strategies
+    for_each = !strcontains(local.capacity_provider, "FARGATE") ? local.placement_strategies : {}
     content {
       field = ordered_placement_strategy.value.field
       type  = ordered_placement_strategy.value.type

--- a/modules/solr/variables.tf
+++ b/modules/solr/variables.tf
@@ -43,6 +43,7 @@ variable "network_mode" {
 }
 
 variable "placement_strategies" {
+  description = "Placement strategies (does not apply when capacity provider is FARGATE)"
   default = {
     pack-by-memory = {
       field = "memory"


### PR DESCRIPTION
- Provide cfg to allow a startup script to run before dspace
- Don't apply placement strategies with FARGATE
