### PR TITLE
Support DSpace v8 solr cores (update default solr cmd args)

### DIFF
--- a/modules/solr/variables.tf
+++ b/modules/solr/variables.tf
@@ -24,6 +24,10 @@ variable "cmd_args" {
     "cp -r /opt/solr/server/solr/configsets/search/* search;",
     "precreate-core statistics /opt/solr/server/solr/configsets/statistics;",
     "cp -r /opt/solr/server/solr/configsets/statistics/* statistics;",
+    "precreate-core qaevent /opt/solr/server/solr/configsets/qaevent;",
+    "cp -r /opt/solr/server/solr/configsets/qaevent/* qaevent;",
+    "precreate-core suggestion /opt/solr/server/solr/configsets/suggestion;",
+    "cp -r /opt/solr/server/solr/configsets/suggestion/* suggestion;",
     "exec solr -f"
   ]
 }


### PR DESCRIPTION
This is backwards compatible. The commands related to v8+ cores
will fail for earlier versions of the DSpace Solr docker img
however Solr will continue to start up as usual.
