### PR TITLE
Add support for setting scaling min capacity

### DIFF
--- a/modules/frontend/autoscaling.tf
+++ b/modules/frontend/autoscaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "this" {
   max_capacity       = local.autoscaling_max_capacity
-  min_capacity       = 1
+  min_capacity       = local.autoscaling_min_capacity
   resource_id        = local.autoscaling_resource_id
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"

--- a/modules/frontend/lb.tf
+++ b/modules/frontend/lb.tf
@@ -16,7 +16,7 @@ resource "aws_lb_target_group" "this" {
   }
 
   stickiness {
-    enabled = true
+    enabled = false
     type    = "lb_cookie"
   }
 

--- a/modules/frontend/locals.tf
+++ b/modules/frontend/locals.tf
@@ -1,7 +1,8 @@
 locals {
   assign_public_ip          = var.assign_public_ip
   autoscaling_cpu_threshold = var.autoscaling_cpu_threshold
-  autoscaling_max_capacity  = var.autoscaling_max_capacity
+  autoscaling_max_capacity  = max(var.autoscaling_max_capacity, local.autoscaling_min_capacity)
+  autoscaling_min_capacity  = var.autoscaling_min_capacity
   autoscaling_resource_id   = "service/${split("/", local.cluster_id)[1]}/${local.name}"
   capacity_provider         = var.capacity_provider
   cluster_id                = var.cluster_id

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -14,6 +14,11 @@ variable "autoscaling_max_capacity" {
   default     = 1
 }
 
+variable "autoscaling_min_capacity" {
+  description = "The minimum number of instances that can be run"
+  default     = 1
+}
+
 variable "capacity_provider" {
   default = "FARGATE"
 }


### PR DESCRIPTION
In the case that min capacity is > than the value for max capacity then max capacity is set to the value of min capacity.