### PR TITLE
startup db command

### DIFF
--- a/modules/backend/locals.tf
+++ b/modules/backend/locals.tf
@@ -35,6 +35,7 @@ locals {
   requires_compatibilities = var.requires_compatibilities
   security_group_id        = var.security_group_id
   solr_url                 = var.solr_url
+  startup_db_cmd           = local.instances > 1 ? "info" : "migrate"
   startup_script           = var.startup_script
   subnets                  = var.subnets
   swap_size                = 2048
@@ -71,6 +72,7 @@ locals {
     port               = local.port
     region             = data.aws_region.current.name
     solr_url           = local.solr_url
+    startup_db_cmd     = local.startup_db_cmd
     startup_script     = local.startup_script
     swap_size          = local.swap_size
     timezone           = local.timezone

--- a/modules/backend/task-definition/rest.json.tpl
+++ b/modules/backend/task-definition/rest.json.tpl
@@ -76,7 +76,7 @@
       "-c",
       "${join(" ", [
         "${startup_script};",
-        "${dspace_dir}/bin/dspace database migrate;",
+        "${dspace_dir}/bin/dspace database ${startup_db_cmd};",
         "catalina.sh run"
       ])}"
     ],


### PR DESCRIPTION
- Set task level cpu only when using fargate
- Create log group per module/deployment, resolves #15
- Use app name for stream prefix (dspace/)
- Use services example for module testing (cloud)
- Remove unused vars from example
- Docs updated
- Update workspace cfg for testing
- Update test setup for solr on ec2
- Use name_prefix with lifecycle rule for tg updates
- Ensure tg name_prefix conforms to 6 char limit
- Use dash with tg prefix
- Update java opts
- Don't restrict cpu alloc to fargate
- Update ex services doc
- Add examples services url
- Support custom env / secrets for frontend, resolves #30
- Create var for dspace name (backend)
- Implement support for redirect paths (to rest server)
- Implement support for (optional) custom robots.txt
- Implement (optional) certbot module
- Add vars for separate task and container memory allocation
- Fix description typo
- Support ecs app autoscaling for the frontend
- Allow sns for task role (#43)
- Give cw and ssm read access & fix app autoscale cluster name
- Chore: consolidate vars usage in locals.tf
- Initial backend iam s3 access
- Support ecs placement strategies
- Add initial dependabot cfg
- Bump hashicorp/setup-terraform from 2 to 3 in /.github/workflows
- Bump actions/checkout from 3 to 4 in /.github/workflows
- Update dependabot and modules
- Bump terraform-aws-modules/ecs/aws in /examples/complete
- Add wildcard for dependabot group match
- Bump the modules group in /examples/complete with 3 updates
- Support swap for dspace backend when using ec2
- Support solr lock type cfg & add ulimits
- Provide cfg to allow a startup script to run before dspace
- Don't apply placement strategies with FARGATE
- Ignore changes to solr srv disc health cfg
- Bump the modules group in /examples/complete with 5 updates
- Enable swap for frontend & solr
- Add ctqueues volme for curate tasks
- Pass capacity provider to taskdef
- Support extra policy arns
- Make the Solr module generic with entrypoint var
- Add handle server module
- Support contact info as envvars for handle
- Bump the modules group in /examples/complete with 6 updates
- Run startup before migrate to ensure env prepped
- Set enabled by default for certbot module
- Support multiple hostnames for certbot module
- Bump the modules group in /examples/complete with 6 updates
- Support DSpace v8 solr cores (update default solr cmd args)
- Fix the default solr cmd_args cp path
- Add support for setting scaling min capacity
- Generate jwt token secret
- Don't run db migrate when running > 1 task
