### PR TITLE
Support to disable frontend logging

### DIFF
--- a/modules/frontend/locals.tf
+++ b/modules/frontend/locals.tf
@@ -55,6 +55,7 @@ locals {
     env                = local.env
     bind               = "0.0.0.0"
     img                = local.img
+    log_driver         = var.log_driver
     log_group          = aws_cloudwatch_log_group.this.name
     name               = local.name
     namespace          = local.namespace

--- a/modules/frontend/task-definition/frontend.json.tpl
+++ b/modules/frontend/task-definition/frontend.json.tpl
@@ -77,7 +77,7 @@
     },
     %{ endif ~}
     "logConfiguration": {
-       %{ if capacity_provider == "FARGATE" }
+       %{ if capacity_provider == "FARGATE" || log_driver == "awslogs" }
           "logDriver": "awslogs",
           "options": {
             "awslogs-group": "${log_group}",
@@ -85,16 +85,7 @@
             "awslogs-stream-prefix": "dspace"
           }
        %{ else }
-          %{ if log_driver == "awslogs" }
-            "logDriver": "${log_driver}",
-            "options": {
-              "awslogs-group": "${log_group}",
-              "awslogs-region": "${region}",
-              "awslogs-stream-prefix": "dspace"
-            }
-          %{ else }
-            "logDriver": "${log_driver}"
-          %{ endif ~}
+          "logDriver": "none"
         %{ endif ~}
     }
   }

--- a/modules/frontend/task-definition/frontend.json.tpl
+++ b/modules/frontend/task-definition/frontend.json.tpl
@@ -77,12 +77,16 @@
     },
     %{ endif ~}
     "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${log_group}",
-        "awslogs-region": "${region}",
-        "awslogs-stream-prefix": "dspace"
-      }
+      %{ if log_driver == "awslogs" }
+        "logDriver": "${log_driver}",
+        "options": {
+          "awslogs-group": "${log_group}",
+          "awslogs-region": "${region}",
+          "awslogs-stream-prefix": "dspace"
+        }
+      %{ else }
+        "logDriver": "${log_driver}"
+      %{ endif ~}
     }
   }
 ]

--- a/modules/frontend/task-definition/frontend.json.tpl
+++ b/modules/frontend/task-definition/frontend.json.tpl
@@ -77,16 +77,25 @@
     },
     %{ endif ~}
     "logConfiguration": {
-      %{ if log_driver == "awslogs" }
-        "logDriver": "${log_driver}",
-        "options": {
-          "awslogs-group": "${log_group}",
-          "awslogs-region": "${region}",
-          "awslogs-stream-prefix": "dspace"
-        }
-      %{ else }
-        "logDriver": "${log_driver}"
-      %{ endif ~}
+       %{ if capacity_provider == "FARGATE" }
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "${log_group}",
+            "awslogs-region": "${region}",
+            "awslogs-stream-prefix": "dspace"
+          }
+       %{ else }
+          %{ if log_driver == "awslogs" }
+            "logDriver": "${log_driver}",
+            "options": {
+              "awslogs-group": "${log_group}",
+              "awslogs-region": "${region}",
+              "awslogs-stream-prefix": "dspace"
+            }
+          %{ else }
+            "logDriver": "${log_driver}"
+          %{ endif ~}
+        %{ endif ~}
     }
   }
 ]

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -79,7 +79,7 @@ variable "listener_priority" {
 
 variable "log_driver" {
   description = "Log Driver currently supported none and awslogs"
-  default = "awslogs"
+  default     = "awslogs"
 }
 
 variable "memory" {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -80,6 +80,11 @@ variable "listener_priority" {
 variable "log_driver" {
   description = "Log Driver currently supported none and awslogs"
   default     = "awslogs"
+
+  validation {
+    condition     = contains(["awslogs", "none"], var.log_driver)
+    error_message = "The log_driver variable must be either awslog or none."
+  }
 }
 
 variable "memory" {

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -77,6 +77,11 @@ variable "listener_priority" {
   description = "ALB (https) listener priority (actual value is: int * 10 + 1)"
 }
 
+variable "log_driver" {
+  description = "Log Driver currently supported none and awslogs"
+  default = "awslogs"
+}
+
 variable "memory" {
   description = "Task level memory allocation (hard limit)"
   default     = 1024


### PR DESCRIPTION
**With logging enabled!**
# module.frontend.aws_ecs_task_definition.this will be created
  + resource "aws_ecs_task_definition" "this" {
      + arn                      = (known after apply)
      + arn_without_revision     = (known after apply)
      + container_definitions    = jsonencode(
            [
              + {
                  + command          = [
                      + "/bin/sh",
                      + "-c",
                      + "node /app/dist/server/main.js",
                    ]
                  + environment      = [
                      + {
                          + name  = "DSPACE_CACHE_SERVERSIDE_ANONYMOUSCACHE_MAX"
                          + value = "500"
                        },
                      + {
                          + name  = "DSPACE_REST_HOST"
                          + value = "dspace-ex-services.dspace.org"
                        },
                      + {
                          + name  = "DSPACE_REST_NAMESPACE"
                          + value = "/server"
                        },
                      + {
                          + name  = "DSPACE_REST_PORT"
                          + value = "443"
                        },
                      + {
                          + name  = "DSPACE_REST_SSL"
                          + value = "true"
                        },
                      + {
                          + name  = "DSPACE_UI_HOST"
                          + value = "0.0.0.0"
                        },
                      + {
                          + name  = "DSPACE_UI_NAMESPACE"
                          + value = "/"
                        },
                      + {
                          + name  = "DSPACE_UI_PORT"
                          + value = "4000"
                        },
                      + {
                          + name  = "DSPACE_UI_SSL"
                          + value = "false"
                        },
                      + {
                          + name  = "NODE_ENV"
                          + value = "production"
                        },
                      + {
                          + name  = "NODE_OPTIONS"
                          + value = "--max-old-space-size=768"
                        },
                    ]
                  + essential        = true
                  + image            = "dspace/dspace-angular:dspace-7_x-dist"
                  + logConfiguration = {
                      + logDriver = "awslogs"
                      + options   = {
                          + awslogs-group         = "/aws/ecs/dspace-ex-services-frontend"
                          + awslogs-region        = "us-west-2"
                          + awslogs-stream-prefix = "dspace"
                        }
                    }
                  + name             = "frontend"
                  + portMappings     = [
                      + {
                          + containerPort = 4000
                        },
                    ]
                  + secrets          = []
                },
            ]
        )
      + cpu                      = "512"
      + execution_role_arn       = "arn:aws:iam::731766341831:role/dspace-dcsp-production-ECSTaskRole"
      + family                   = "dspace-ex-services-frontend"
      + id                       = (known after apply)
      + memory                   = "1024"
      + network_mode             = "awsvpc"
      + requires_compatibilities = [
          + "FARGATE",
        ]
      + revision                 = (known after apply)
      + skip_destroy             = false
      + tags_all                 = (known after apply)
      + task_role_arn            = "arn:aws:iam::731766341831:role/dspace-dcsp-production-ECSTaskRole"
      + track_latest             = false
    }



**With logging disabled!**


  # module.frontend.aws_ecs_task_definition.this will be created
  + resource "aws_ecs_task_definition" "this" {
      + arn                      = (known after apply)
      + arn_without_revision     = (known after apply)
      + container_definitions    = jsonencode(
            [
              + {
                  + command          = [
                      + "/bin/sh",
                      + "-c",
                      + "node /app/dist/server/main.js",
                    ]
                  + environment      = [
                      + {
                          + name  = "DSPACE_CACHE_SERVERSIDE_ANONYMOUSCACHE_MAX"
                          + value = "500"
                        },
                      + {
                          + name  = "DSPACE_REST_HOST"
                          + value = "dspace-ex-services.dspace.org"
                        },
                      + {
                          + name  = "DSPACE_REST_NAMESPACE"
                          + value = "/server"
                        },
                      + {
                          + name  = "DSPACE_REST_PORT"
                          + value = "443"
                        },
                      + {
                          + name  = "DSPACE_REST_SSL"
                          + value = "true"
                        },
                      + {
                          + name  = "DSPACE_UI_HOST"
                          + value = "0.0.0.0"
                        },
                      + {
                          + name  = "DSPACE_UI_NAMESPACE"
                          + value = "/"
                        },
                      + {
                          + name  = "DSPACE_UI_PORT"
                          + value = "4000"
                        },
                      + {
                          + name  = "DSPACE_UI_SSL"
                          + value = "false"
                        },
                      + {
                          + name  = "NODE_ENV"
                          + value = "production"
                        },
                      + {
                          + name  = "NODE_OPTIONS"
                          + value = "--max-old-space-size=768"
                        },
                    ]
                  + essential        = true
                  + image            = "dspace/dspace-angular:dspace-7_x-dist"
                  + logConfiguration = {
                      + logDriver = "none"
                    }
                  + name             = "frontend"
                  + portMappings     = [
                      + {
                          + containerPort = 4000
                        },
                    ]
                  + secrets          = []
                },
            ]
        )
      + cpu                      = "512"
      + execution_role_arn       = "arn:aws:iam::731766341831:role/dspace-dcsp-production-ECSTaskRole"
      + family                   = "dspace-ex-services-frontend"
      + id                       = (known after apply)
      + memory                   = "1024"
      + network_mode             = "awsvpc"
      + requires_compatibilities = [
          + "FARGATE",
        ]
      + revision                 = (known after apply)
      + skip_destroy             = false
      + tags_all                 = (known after apply)
      + task_role_arn            = "arn:aws:iam::731766341831:role/dspace-dcsp-production-ECSTaskRole"
      + track_latest             = false
    }